### PR TITLE
Allow config to be read from a JS file

### DIFF
--- a/src/config/openConfig.ts
+++ b/src/config/openConfig.ts
@@ -15,7 +15,9 @@ export type OpenError = {
   readonly message: string;
 };
 export type OpenResult = OpenSuccess | OpenError;
-export type FileName = ".folder-structure-lint.json";
+export type FileName =
+  | ".folder-structure-lint.json"
+  | ".folder-structure-lint.js";
 
 export async function openConfig(): Promise<OpenResult> {
   return new Promise<OpenResult>((accept) => {

--- a/src/config/readConfigFile.ts
+++ b/src/config/readConfigFile.ts
@@ -5,13 +5,36 @@
 import fs from "fs";
 import { buildReadConfigFileCallback } from "./buildReadConfigFileCallback";
 import { OpenResult } from "./openConfig";
+import path from "path";
+import { CheckedConfig } from "./execute";
 
 // eslint-disable-next-line functional/no-return-void, @typescript-eslint/prefer-readonly-parameter-types
 export type Accept = (value: OpenResult | PromiseLike<OpenResult>) => void;
 
 export const configFile = ".folder-structure-lint.json";
-export const message = `Could not open the config file "${configFile}"`;
+export const jsConfigFile = ".folder-structure-lint.js";
+export const message = `Could not open the config file "${configFile}" or "${jsConfigFile}"`;
 
+type MaybeCheckedConfig = Partial<CheckedConfig>;
+
+// eslint-disable-next-line max-lines-per-function
 export function readConfigFile(accept: Accept) {
-  fs.readFile(configFile, "utf8", buildReadConfigFileCallback(accept));
+  if (fs.existsSync(jsConfigFile)) {
+    const absolutePath = path.resolve(jsConfigFile);
+
+    // eslint-disable-next-line functional/no-try-statement
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const config = require(absolutePath) as MaybeCheckedConfig;
+
+      accept({ tag: "open-success", result: config });
+    } catch {
+      accept({
+        tag: "open-error",
+        message,
+      });
+    }
+  } else {
+    fs.readFile(configFile, "utf8", buildReadConfigFileCallback(accept));
+  }
 }


### PR DESCRIPTION
This PR aims to allow folder-structure-lint the ability to read from JS configs

Allowing a JS config to be accepted allows all sorts of possibilities like sharable/extendable configs, dynamic configs, etc

Fixes #2 